### PR TITLE
Fix the aspect ratio for fluid breakpoints' steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export default ({publicId}) => (
             cloudName={'cloud'}
             imageName={publicId}
             fluid={{
-                width: 300,
+                maxWidth: 300,
                 height: 300
             }}
             style={{
@@ -87,23 +87,23 @@ by setting `urlParams`. You can also find all formats that can be passed to `img
 
 ## Props
 
-| Name                   | Type                | Description                                                                                                                                          |
-| ---------------------- | ------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `fixed`                | `object`            | Object with 'width' and 'height' properties                                                                                                          |
-| `fluid`                | `object`            | Object with 'maxWidth' required property. Optionally step, _default_=150 and 'height'. If height not set, uses 'c_scale' otherwise 'c_lfill'         |
-| `fadeIn`               | `bool`              | Defaults to fading in the image on load                                                                                                              |
-| `cloudName`            | `string`            | Cloudinary cloud name, _default_=process.env.CLOUD_NAME or process.env.REACT_APP_CLOUD_NAME                                                          |
-| `imageName`            | `string`            | Cloudinary publicId                                                                                                                                  |
-| `urlParams`            | `string`            | Cloudinary image transformations params. Overrides default 'c_lfill' or 'c_scale'                                                                    |
-| `title`                | `string`            | Passed to the `img` element                                                                                                                          |
-| `alt`                  | `string`            | Passed to the `img` element                                                                                                                          |
-| `style`                | `object`            | Spread into the default styles of the wrapper element                                                                                                |
-| `imgStyle`             | `object`            | Spread into the default styles of the actual `img` element                                                                                           |
-| `placeholderStyle`     | `object`            | Spread into the default styles of the placeholder `img` element                                                                                      |
-| `backgroundColor`      | `string` / `bool`   | Set a colored background placeholder instead of "blur-up". If true, uses _default_ "lightgray" color. You can also pass in any valid color string.   |
-| `onLoad`               | `func`              | A callback that is called when the full-size image has loaded.                                                                                       |
-| `onError`              | `func`              | A callback that is called when the image fails to load.                                                                                              |
-| `imgFormat`            | `string` / `bool`   | Allow Cloudinary to format image. By default is set to 'f_auto'. Can be switch off by passing 'false' or be formatted to specific format (ex. 'webp')|
-| `quality`              | `string` / `bool`   | Allow Cloudinary to change quality of image. By default is set to 'q_auto'. Can be switch off by passing 'false' or to specific value (ex. 'best')   |
+| Name               | Type              | Description                                                                                                                                           |
+| ------------------ | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fixed`            | `object`          | Object with 'width' and 'height' properties                                                                                                           |
+| `fluid`            | `object`          | Object with 'maxWidth' required property. Optionally step, _default_=150 and 'height'. If height not set, uses 'c_scale' otherwise 'c_lfill'          |
+| `fadeIn`           | `bool`            | Defaults to fading in the image on load                                                                                                               |
+| `cloudName`        | `string`          | Cloudinary cloud name, _default_=process.env.CLOUD_NAME or process.env.REACT_APP_CLOUD_NAME                                                           |
+| `imageName`        | `string`          | Cloudinary publicId                                                                                                                                   |
+| `urlParams`        | `string`          | Cloudinary image transformations params. Overrides default 'c_lfill' or 'c_scale'                                                                     |
+| `title`            | `string`          | Passed to the `img` element                                                                                                                           |
+| `alt`              | `string`          | Passed to the `img` element                                                                                                                           |
+| `style`            | `object`          | Spread into the default styles of the wrapper element                                                                                                 |
+| `imgStyle`         | `object`          | Spread into the default styles of the actual `img` element                                                                                            |
+| `placeholderStyle` | `object`          | Spread into the default styles of the placeholder `img` element                                                                                       |
+| `backgroundColor`  | `string` / `bool` | Set a colored background placeholder instead of "blur-up". If true, uses _default_ "lightgray" color. You can also pass in any valid color string.    |
+| `onLoad`           | `func`            | A callback that is called when the full-size image has loaded.                                                                                        |
+| `onError`          | `func`            | A callback that is called when the image fails to load.                                                                                               |
+| `imgFormat`        | `string` / `bool` | Allow Cloudinary to format image. By default is set to 'f_auto'. Can be switch off by passing 'false' or be formatted to specific format (ex. 'webp') |
+| `quality`          | `string` / `bool` | Allow Cloudinary to change quality of image. By default is set to 'q_auto'. Can be switch off by passing 'false' or to specific value (ex. 'best')    |
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -190,13 +190,14 @@ class Image extends React.Component {
     }
     return results.join(',')
   }
+
   createBrakePointsFluid (urlCore) {
     const image = this.props.fluid
     const step = image.step || 150
     let size = 150
-    const results = []
+    const results = []    
     while (size < image.maxWidth) {
-      const params = `${urlCore},w_${size}${image.height ? `,h_${image.height}` : ''}`
+      const params = `${urlCore},w_${size}${image.height ? `,h_${Math.ceil(size * this.getAspectRatio(image))}` : ''}`
       results.push(`https://res.cloudinary.com/${this.props.cloudName}/image/upload/${params}/${this.props.imageName} ${size}w`)
       size = size + step
     }
@@ -205,6 +206,12 @@ class Image extends React.Component {
       `https://res.cloudinary.com/${this.props.cloudName}/image/upload/${urlCore},w_${image.maxWidth}${image.height ? `,h_${image.height}` : ''}/${this.props.imageName} ${image.maxWidth}w`
     )
     return results.join(',')
+  }
+
+  getAspectRatio(image) {
+    return image.height > image.maxWidth
+      ? image.height / image.maxWidth
+      : image.maxWidth / image.height
   }
 
   render () {


### PR DESCRIPTION
Hi,
   when the height is set for the fluid version, every step use the original height instead of the right one for its size.